### PR TITLE
fix: add Types to mongoose exports to support ObjectId related operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,11 +2,15 @@
 
 Object.defineProperty(exports, "__esModule", { value: true });
 
-const dummyObj = {}
+const dummyObj = {};
 const dummyProxy = new Proxy(dummyObj, {
-    get() {
-        return dummyProxy;
-    }
-})
+  get() {
+    return dummyProxy;
+  },
+});
 
+class ObjectId {}
+exports.Types = {
+  ObjectId,
+};
 exports.default = dummyProxy;


### PR DESCRIPTION
Thanks for creating this patch.

I had an issue when using `Types` import for `ObjectId` operations. Ex: `new Types.ObjectId()`

As part of this PR, I am adding `Types` to the mongoose exports